### PR TITLE
add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners will be requested for review when someone opens a pull request.
+*       @ASFHyP3/platform


### PR DESCRIPTION
I think the asf-stac repository will need to be added to our various ASFHyP3 github teams.