### PR TITLE
set search path in configure-database-roles.sql

### DIFF
--- a/configure-database-roles.sql
+++ b/configure-database-roles.sql
@@ -2,3 +2,4 @@
 
 ALTER ROLE pgstac_read LOGIN PASSWORD :'db_read_password';
 GRANT SELECT ON pgstac.collections TO pgstac_read;
+ALTER DATABASE postgres set search_path to pgstac, public;


### PR DESCRIPTION
Per https://stac-utils.github.io/pgstac/pgstac/#pgstac-search-path , the postgres [search path](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH) needs to be set to avoid namespace issues when logged in as non-pgstac users such as `postgres`.

See https://github.com/stac-utils/pgstac/issues/149 for an example error.

This PR sets the search path for all users at the database level at bootstrap time, so we don't have to remember to do it manually. I think it's better to do here than in install-or-upgrade-postgis.sql , since it's pgstac-specific, but the script might be better renamed "configure-pgstac.sql". Any thoughts?