### PR TITLE
Disable transaction endpoints for public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1]
+### Security
+- Removed Transaction endpoints from the publicly available API, though create/update/delete permissions were already
+  restricted at the database layer.
+
 ## [0.3.0]
 ### Added
 - Created a STAC item collection for the `glo-30-hand` dataset.

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ pypgstac-load:
 run-api:
 	POSTGRES_HOST_READER=${db_host} POSTGRES_HOST_WRITER=${db_host} POSTGRES_PORT=5432 \
 	    POSTGRES_DBNAME=postgres POSTGRES_USER=postgres POSTGRES_PASS=${db_admin_password} \
+	    ENABLED_EXTENSIONS=${enabled_extensions} \
 	    python -m stac_fastapi.pgstac.app
 
 test:

--- a/README.md
+++ b/README.md
@@ -132,14 +132,18 @@ Run:
 make run-api db_host=<host> db_admin_password=<password>
 ```
 
+You can also append an `enabled_extensions=<list>` argument, where `<list>` is the list of extensions
+that gets passed to the `pgstac` app via the `ENABLED_EXTENSIONS` environment variable, as described
+in the docstring for the
+[module](https://github.com/stac-utils/stac-fastapi/blob/master/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py).
+
 You should see something like `Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)` in the output; you can
 query the API at that URL.
 
 You can confirm that the Transaction extension is enabled by opening the local API URL in a web browser
 and appending `/api.html` to open the Swagger UI. You should see various create/update/delete endpoints
-under the "Transaction Extension" heading. You should be able to successfully query these endpoints via
-the local API, but not via the publicly available API. (TODO: after removing those endpoints completely
-from the public API, update this paragraph to reflect that they will no longer appear in the Swagger UI.)
+under the "Transaction Extension" heading. These endpoints should not appear in the Swagger UI for the
+publicly available API.
 
 ## Upgrading the database
 

--- a/apps/api/src/api.py
+++ b/apps/api/src/api.py
@@ -1,1 +1,12 @@
-from stac_fastapi.pgstac.app import handler  # noqa: F401
+import os
+
+os.environ['ENABLED_EXTENSIONS'] = ','.join([
+    'query',
+    'sort',
+    'fields',
+    'pagination',
+    'context',
+    'filter',
+])
+
+from stac_fastapi.pgstac.app import handler  # noqa: F401, E402


### PR DESCRIPTION
See https://github.com/ASFHyP3/asf-stac/issues/87

If we don't want to specify the entire list of collections, we could also import `extensions_map` from the [pgstac app](https://github.com/stac-utils/stac-fastapi/blob/master/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py) and generate the list of extensions by removing `transaction` and `bulk_transactions` from `extensions_map.keys()`.

* I confirmed that removing an extension from the list passed to the local API (via the `make run-api` command) also removes the corresponding endpoints from the Swagger UI.
* I observed that removing the Transaction extension from the list results in a `Method Not Allowed` error when attempting to `curl` a Transaction endpoint (tested by trying to `DELETE` an item or `POST` or `PUT` a collection).