### PR TITLE
Remove Filter extension

### DIFF
--- a/apps/api/src/api.py
+++ b/apps/api/src/api.py
@@ -6,7 +6,6 @@ os.environ['ENABLED_EXTENSIONS'] = ','.join([
     'fields',
     'pagination',
     'context',
-    'filter',
 ])
 
 from stac_fastapi.pgstac.app import handler  # noqa: F401, E402


### PR DESCRIPTION
See https://github.com/ASFHyP3/asf-stac/issues/139

I also verified that the other enabled extensions appear to be working and are at least in [Candidate maturity](https://github.com/radiantearth/stac-api-spec/blob/v1.0.0-rc.1/README.md#maturity-classification).