### PR TITLE
code review feedback for addition of dem url link

### DIFF
--- a/tests/test_create_hand_items.py
+++ b/tests/test_create_hand_items.py
@@ -3,6 +3,16 @@ from datetime import datetime, timezone
 import create_hand_items
 
 
+def test_get_dem_url():
+    expected = 'https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com/Copernicus_DSM_COG_10_N00_00_E006_00_DEM/' \
+               'Copernicus_DSM_COG_10_N00_00_E006_00_DEM.tif'
+    assert create_hand_items.get_dem_url('Copernicus_DSM_COG_10_N00_00_E006_00_HAND') == expected
+
+    expected = 'https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com/Copernicus_DSM_COG_10_S81_00_W132_00_DEM/' \
+               'Copernicus_DSM_COG_10_S81_00_W132_00_DEM.tif'
+    assert create_hand_items.get_dem_url('Copernicus_DSM_COG_10_S81_00_W132_00_HAND') == expected
+
+
 def test_gdal_info():
     assert create_hand_items.gdal_info(
         'v1/2021/Copernicus_DSM_COG_10_N02_00_W062_00_HAND.tif',
@@ -18,6 +28,44 @@ def test_gdal_info():
 
 
 def test_create_stac_item():
+    expected = {
+        'type': 'Feature',
+        'stac_version': '1.0.0',
+        'id': 'Copernicus_DSM_COG_10_N00_00_E006_00_HAND',
+        'properties': {
+            'datetime': None,
+            'start_datetime': datetime(2010, 12, 1, tzinfo=timezone.utc),
+            'end_datetime': datetime(2015, 2, 1, tzinfo=timezone.utc),
+        },
+        'geometry': {
+            'type': 'Polygon',
+            'coordinates': [[[5.9998611, 1.0001389],
+                             [5.9998611, 0.0001389],
+                             [6.9998611, 0.0001389],
+                             [6.9998611, 1.0001389],
+                             [5.9998611, 1.0001389]]],
+        },
+        'assets': {
+            'data': {
+                'href': 'foo.com/v1/2021/Copernicus_DSM_COG_10_N00_00_E006_00_HAND.tif',
+                'type': 'image/tiff; application=geotiff',
+            },
+        },
+        'bbox': (5.9998611, 0.0001389, 6.9998611, 1.0001389),
+        'stac_extensions': [],
+        'collection': create_hand_items.COLLECTION_ID,
+        'links': [
+            {
+                'href': 'https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com/'
+                        'Copernicus_DSM_COG_10_N00_00_E006_00_DEM/Copernicus_DSM_COG_10_N00_00_E006_00_DEM.tif',
+                'type': 'image/tiff; application=geotiff',
+                'title': 'GLO-30 Public Copernicus Digital Elevation Model GeoTIFF '
+                         'used as input to create this HAND GeoTIFF',
+                'rel': 'related',
+            },
+        ],
+    }
+
     assert create_hand_items.create_stac_item(
         'v1/2021/Copernicus_DSM_COG_10_N00_00_E006_00_HAND.tif',
         'foo.com/',
@@ -29,40 +77,4 @@ def test_create_stac_item():
                              [6.9998611, 1.0001389],
                              [5.9998611, 1.0001389]]],
         }},
-    ) == {
-            'type': 'Feature',
-            'stac_version': '1.0.0',
-            'id': 'Copernicus_DSM_COG_10_N00_00_E006_00_HAND',
-            'properties': {
-                'datetime': None,
-                'start_datetime': datetime(2010, 12, 1, tzinfo=timezone.utc),
-                'end_datetime': datetime(2015, 2, 1, tzinfo=timezone.utc),
-            },
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[5.9998611, 1.0001389],
-                                 [5.9998611, 0.0001389],
-                                 [6.9998611, 0.0001389],
-                                 [6.9998611, 1.0001389],
-                                 [5.9998611, 1.0001389]]],
-            },
-            'assets': {
-                'data': {
-                    'href': 'foo.com/v1/2021/Copernicus_DSM_COG_10_N00_00_E006_00_HAND.tif',
-                    'type': 'image/tiff; application=geotiff',
-                },
-            },
-            'bbox': (5.9998611, 0.0001389, 6.9998611, 1.0001389),
-            'stac_extensions': [],
-            'collection': create_hand_items.COLLECTION_ID,
-            'links': [
-                {
-                    'href': 'https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com/'
-                            'Copernicus_DSM_COG_10_N00_00_E006_00_DEM/Copernicus_DSM_COG_10_N00_00_E006_00_DEM.tif',
-                    'type': 'image/tiff; application=geotiff',
-                    'title': 'GLO-30 Public Copernicus Digital Elevation Model GeoTIFF '
-                             'used as input to create this HAND GeoTIFF',
-                    'rel': 'related',
-                },
-            ],
-       }
+    ) == expected


### PR DESCRIPTION
Providing code feedback as a PR, feel free to merge this as-is, or cherry-pick individual changes if you don't want to accept all of them.

- Renamed `get_dem_s3_url` to `get_dem_url`; "s3_url" suggests the function might return a `s3://` path rather than a `https://` path
- updated `get_dem_url` to take the hand item id so we don't have to repeat the path/stem business logic in two places
- added a few tests for `get_dem_url`
- converted a few double-quotes to single quotes
- fixed an unintentional indentation change in `create_stac_item`
- save the expected output for `test_create_stac_item` to a local variable to simplify the indentation