### PR TITLE
switch tests workflow to micromamba

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/checkout@v3.1.0
 
       - name: edit environment.yml
-        # Edit environment.yml to specify the absolute path for requirements.txt TODO why?
+        # Edit environment.yml to specify the absolute path for requirements.txt as a workaround for
+        # https://github.com/mamba-org/provision-with-micromamba/issues/108
         run: sed -i "s_requirements.txt_${PWD}/requirements.txt_" environment.yml
 
       - uses: mamba-org/provision-with-micromamba@v14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: mamba-org/provision-with-micromamba@v14
         with:
-          mamba-version: '*'
-          python-version: '3.9'
-          activate-environment: asf-stac
           environment-file: environment.yml
+          extra-specs: |
+            python=3.9
 
       - name: run pytest
         run: make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
+      - name: edit environment.yml
+        # Edit environment.yml to specify the absolute path for requirements.txt TODO why?
+        run: sed -i "s_requirements.txt_${PWD}/requirements.txt_" environment.yml
+
       - uses: conda-incubator/setup-miniconda@v2
         with:
           mamba-version: '*'


### PR DESCRIPTION
Pytest is failing because our environment.yml file points at a separate requirements.txt file, see https://github.com/mamba-org/provision-with-micromamba/issues/108