### PR TITLE
simplify stac dependencies

### DIFF
--- a/requirements-apps-api.txt
+++ b/requirements-apps-api.txt
@@ -1,5 +1,2 @@
 mangum==0.17.0
-stac-fastapi.api==2.5.5.post1
-stac-fastapi.extensions==2.5.5.post1
 stac-fastapi.pgstac==2.5.0
-stac-fastapi.types==2.5.5.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,12 @@
 boto3==1.34.149
 cfn-lint==1.8.2
 flake8==7.1.1
-pypgstac[psycopg]==0.7.10
+
+# Installs the extra psycopg dependencies, but leaves the version unspecified,
+# so that the version of pypgstac required by stac-fastapi.pgstac (in requirements-apps-api.txt)
+# will be installed.
+pypgstac[psycopg]
+
 pystac==1.10.1
 pytest==8.3.2
 requests==2.32.3


### PR DESCRIPTION
Dependabot PRs frequently fail because our STAC-related dependency pins are too strict (see the two currently open under https://github.com/ASFHyP3/asf-stac/pulls for examples), so this PR loosens those pins:

* Listing `stac-fastapi.pgstac` is enough to pull in the three other `stac-fastapi.*` dependencies, so those three dependencies can be removed from the requirements file.
* We still need to specify `pypgstac[psycopg]` to get the extra `psycopg` dependencies, but we can leave off the version pin and allow `stac-fastapi.pgstac` to determine the version.

I think `pystac` is mixed up in the dependency graph as well, but I couldn't immediately determine which other package(s) might depend on it, so I'm fine with leaving `pystac` pinned until we see problems with it.