### PR TITLE
pin pypgstac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,7 @@
 boto3==1.34.149
 cfn-lint==1.9.7
 flake8==7.1.1
-
-# Installs the extra psycopg dependencies, but leaves the version unspecified,
-# so that the version of pypgstac required by stac-fastapi.pgstac (in requirements-apps-api.txt)
-# will be installed.
-pypgstac[psycopg]
-
+pypgstac[psycopg]==0.7.10
 pystac==1.10.1
 pytest==8.3.2
 requests==2.32.3


### PR DESCRIPTION
We removed the `pypgstac` pin in https://github.com/ASFHyP3/asf-stac/pull/618. I recall that there was a dependabot PR for `pypgstac` which was failing because `stac-fastapi.pgstac` required a lower version of `pypgstac`, but I can't seem to find that dependabot PR now.

Merging https://github.com/ASFHyP3/asf-stac/pull/618 caused our CodeBuild workflow to fail with:

```
ERROR: Invalid requirement: '#': Expected package name at the start of dependency specifier
    #
    ^
make: *** [Makefile:6: install-pypgstac] Error 1
```

because `make install-pypgstac` attempts to run `python -m pip install $$(grep pypgstac requirements.txt)`, and `grep pypgstac requirements.txt` now matches one of the comment lines.

This would be an easy error to fix, but I think we probably do want to pin the version of `pypgstac` installed for the CodeBuild workflow. We could have a separate requirements file for the CodeBuild workflow, which would not be included in our main `requirements.txt` file, but then we wouldn't be able to build a single local development environment that includes all of our pinned dependencies. We could have two `environment.yml` files depending on which environment you want to work in, but that sounds annoying.

So, I'm just going to revert the change for now, and we can revisit this issue if we get annoyed by failing dependabot PRs.